### PR TITLE
fix: store string fields without their trailing NUL so exact string filters match

### DIFF
--- a/zvec/src/doc.rs
+++ b/zvec/src/doc.rs
@@ -122,7 +122,11 @@ impl Doc {
     pub fn add_string(&mut self, name: &str, value: &str) -> Result<()> {
         let c_name = to_cstring(name)?;
         let c_value = to_cstring(value)?;
-        let bytes = c_value.as_bytes_with_nul();
+        // The C API `zvec_doc_add_field_by_value` is length-delimited: it stores
+        // exactly `size` bytes. Use `as_bytes()` (without the trailing NUL) so the
+        // stored value is the string itself; sending `as_bytes_with_nul()` would
+        // append a NUL to the stored data and break exact string filters.
+        let bytes = c_value.as_bytes();
         check_error(unsafe {
             zvec_sys::zvec_doc_add_field_by_value(
                 self.handle,

--- a/zvec/tests/string_filter_test.rs
+++ b/zvec/tests/string_filter_test.rs
@@ -1,0 +1,85 @@
+//! Regression test for exact string filters.
+//!
+//! A string field written via `Doc::add_string` must be stored as its exact
+//! bytes so that an exact filter (`name = 'alice'`) matches it. This guards
+//! against the trailing-NUL regression where the stored value was `"alice\0"`,
+//! causing exact string filters to return zero rows.
+//!
+//! Requires the zvec C library (`libzvec_c_api`). Set `ZVEC_LIB_DIR` before
+//! running. Run with: `cargo test --test string_filter_test`
+
+use std::sync::Once;
+use zvec::*;
+
+static INIT: Once = Once::new();
+
+fn ensure_initialized() {
+    INIT.call_once(|| {
+        initialize(None).expect("failed to initialize zvec");
+    });
+}
+
+#[test]
+fn test_exact_string_filter_returns_matching_rows() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let dir = tmp_dir.path().join("zvec_data");
+
+    // Collection with an indexed String field and a vector field to search over.
+    let schema = CollectionSchema::builder("string_filter_test")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0).unwrap())
+        .add_indexed_field(
+            "name",
+            DataType::String,
+            IndexParams::invert(false, false).unwrap(),
+        )
+        .add_vector_field(
+            "embedding",
+            DataType::VectorFp32,
+            2,
+            IndexParams::hnsw(MetricType::Cosine, 16, 200).unwrap(),
+        )
+        .build()
+        .expect("failed to build schema");
+
+    let collection = Collection::create_and_open(dir.to_str().unwrap(), &schema, None)
+        .expect("failed to create collection");
+
+    // Insert docs with two "alice" rows and two non-matching rows.
+    let names = ["alice", "bob", "alice", "carol"];
+    let mut docs = Vec::new();
+    for (i, name) in names.iter().enumerate() {
+        let mut doc = Doc::new().unwrap();
+        doc.set_pk(&format!("pk_{}", i));
+        doc.add_string("id", &format!("pk_{}", i)).unwrap();
+        doc.add_string("name", name).unwrap();
+        doc.add_vector_f32("embedding", &[0.1, 0.2]).unwrap();
+        docs.push(doc);
+    }
+    let doc_refs: Vec<&Doc> = docs.iter().collect();
+    let result = collection.insert(&doc_refs).unwrap();
+    assert_eq!(result.success_count, names.len() as u64);
+    collection.flush().expect("flush before filter query");
+
+    // Search over all docs (topk >= doc count) with an exact string filter.
+    let mut query = SearchQuery::new("embedding", &[0.1, 0.2], names.len() as i32).unwrap();
+    query.set_filter("name = 'alice'").unwrap();
+
+    let results = collection.query(&query).unwrap();
+
+    // Exactly the two "alice" rows must come back. Pre-fix (trailing NUL) this
+    // returns 0 rows because the stored value is "alice\0" != "alice".
+    assert_eq!(
+        results.len(),
+        2,
+        "exact string filter should return exactly the matching rows"
+    );
+    for doc in &results {
+        assert_eq!(
+            doc.get_string("name").unwrap().as_deref(),
+            Some("alice"),
+            "every returned row must match the filter"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`Doc::add_string` stores every string field with a trailing NUL byte, which makes exact string filters fail to match. This changes it to store the exact string bytes.

## Root cause

`add_string` passes the value to the length-delimited C API `zvec_doc_add_field_by_value(name, type, *value, size)` using `CString::as_bytes_with_nul()`:

```rust
let bytes = c_value.as_bytes_with_nul();
zvec_sys::zvec_doc_add_field_by_value(
    self.handle,
    c_name.as_ptr(),
    DataType::String as u32,
    bytes.as_ptr() as *const c_void,
    bytes.len(),
);
```

That API is length-delimited: it stores exactly `size` bytes. So the trailing NUL becomes part of the stored value, and every string ends up stored as `"value\0"`.

The read path hides it. `get_string` and `fetch` round-trip correctly, so the stored value looks fine. Exact filters do not:

- `field = 'value'`, `IN (...)`, exact `LIKE 'value'`, and `!=` all fail to match, because the stored bytes are `"value\0"` and the literal is `"value"`.
- Prefix `LIKE 'val%'` and range comparisons such as `>=` still work, because a trailing byte does not disturb a prefix match or an ordering comparison.

Integer and bool equality are unaffected. Those setters send fixed-size buffers with no trailing NUL.

## Reproduction

```rust
use zvec::*;

initialize(None).unwrap();
let schema = CollectionSchema::builder("repro")
    .add_field(FieldSchema::new("id", DataType::String, false, 0).unwrap())
    .add_indexed_field("name", DataType::String, IndexParams::invert(false, false).unwrap())
    .add_vector_field("embedding", DataType::VectorFp32, 2,
        IndexParams::hnsw(MetricType::Cosine, 16, 200).unwrap())
    .build().unwrap();

let dir = tempfile::tempdir().unwrap();
let c = Collection::create_and_open(dir.path().join("data").to_str().unwrap(), &schema, None).unwrap();

for (i, name) in ["alice", "bob"].iter().enumerate() {
    let mut d = Doc::new().unwrap();
    d.set_pk(&format!("pk_{i}"));
    d.add_string("id", &format!("pk_{i}")).unwrap();
    d.add_string("name", name).unwrap();
    d.add_vector_f32("embedding", &[0.1, 0.2]).unwrap();
    c.insert(&[&d]).unwrap();
}
c.flush().unwrap();

let mut q = SearchQuery::new("embedding", &[0.1, 0.2], 10).unwrap();
q.set_filter("name = 'alice'").unwrap();
println!("rows = {}", c.query(&q).unwrap().len()); // 0 before this fix, 1 after
```

## Fix

Send `as_bytes()` instead of `as_bytes_with_nul()` so the stored value is exactly the string:

```rust
let bytes = c_value.as_bytes();
```

Interior NULs are still rejected upstream by `to_cstring`, so this does not weaken input validation. `add_string` is the only setter that used `as_bytes_with_nul`; the numeric, vector, binary, and array setters already pass raw buffers with explicit sizes.

## Test

Adds `zvec/tests/string_filter_test.rs`: it inserts documents into a collection with an indexed String field and asserts that an exact `name = 'alice'` filter returns exactly the matching rows. It fails before the fix (0 rows) and passes after. The full `zvec` test suite is green against the v0.5.0 prebuilt library (160 passed, 1 ignored).
