### PR TITLE
feat: add SearchQuery::fts for pure keyword-only (vector-less) search

### DIFF
--- a/zvec/src/query.rs
+++ b/zvec/src/query.rs
@@ -259,6 +259,37 @@ impl SearchQuery {
         Ok(query)
     }
 
+    /// Creates a pure full-text (keyword-only) search query with no dense vector.
+    ///
+    /// [`SearchQuery::new`] and [`SearchQueryBuilder::build`] both require a query
+    /// vector, so an FTS clause can only ever be layered on top of a dense vector
+    /// (hybrid search). This constructor reaches the C API's vector-less FTS path:
+    /// once an FTS payload is attached, the underlying `zvec_vector_query` does not
+    /// require a query vector, enabling keyword-only retrieval.
+    ///
+    /// `field_name` must be the FTS-indexed field.
+    pub fn fts(field_name: &str, fts: &Fts, topk: i32) -> Result<Self> {
+        let handle = unsafe { zvec_rust_sys::zvec_vector_query_create() };
+        if handle.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create vector query".into(),
+            });
+        }
+
+        // Wrap the handle before any fallible call so `Drop` frees it on early return.
+        let mut query = SearchQuery { handle };
+        let c_field = to_cstring(field_name)?;
+
+        check_error(unsafe {
+            zvec_rust_sys::zvec_vector_query_set_field_name(query.handle, c_field.as_ptr())
+        })?;
+        check_error(unsafe { zvec_rust_sys::zvec_vector_query_set_topk(query.handle, topk) })?;
+        query.set_fts(fts)?;
+
+        Ok(query)
+    }
+
     /// Returns a builder for constructing a search query.
     pub fn builder() -> SearchQueryBuilder {
         SearchQueryBuilder::new()
@@ -731,5 +762,21 @@ mod tests {
             .field_name("test_field")
             .vector(&large_vector);
         assert_eq!(builder.vector.as_ref().unwrap().len(), 1024);
+    }
+
+    #[test]
+    fn test_fts_query_no_vector() {
+        // A pure FTS query must build without a query vector; the builder path
+        // (which requires `vector`) cannot express this.
+        let mut fts = Fts::new().expect("create fts payload");
+        fts.set_match_string("hello world")
+            .expect("set match string");
+
+        let query = SearchQuery::fts("content", &fts, 10);
+        assert!(
+            query.is_ok(),
+            "pure FTS query should build without a vector"
+        );
+        assert!(!unsafe { query.unwrap().as_raw() }.is_null());
     }
 }

--- a/zvec/tests/fts_no_vector_test.rs
+++ b/zvec/tests/fts_no_vector_test.rs
@@ -1,0 +1,87 @@
+//! End-to-end test for pure full-text (keyword-only) search with no vector.
+//!
+//! `SearchQuery::new` and `SearchQueryBuilder::build` both require a query
+//! vector, so a keyword-only query can only be built via `SearchQuery::fts`.
+//! This mirrors the C `test_fts_end_to_end` case: a schema with an FTS-indexed
+//! string field and no vector field, queried with a match string alone.
+//!
+//! Requires the zvec C library (`libzvec_c_api`). Set `ZVEC_LIB_DIR` before
+//! running. Run with: `cargo test --test fts_no_vector_test`
+
+use std::sync::Once;
+use zvec_rust::*;
+
+static INIT: Once = Once::new();
+
+fn ensure_initialized() {
+    INIT.call_once(|| {
+        initialize(None).expect("failed to initialize zvec");
+    });
+}
+
+#[test]
+fn test_fts_only_query_returns_keyword_matches() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let dir = tmp_dir.path().join("zvec_data");
+
+    // Schema with an FTS-indexed string field and NO vector field.
+    let schema = CollectionSchema::builder("fts_no_vector_test")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0).unwrap())
+        .add_indexed_field(
+            "content",
+            DataType::String,
+            IndexParams::fts(None, None, None).unwrap(),
+        )
+        .build()
+        .expect("failed to build schema");
+
+    let collection = Collection::create_and_open(dir.to_str().unwrap(), &schema, None)
+        .expect("failed to create collection");
+
+    // Two docs mention "learning"; one does not.
+    let texts = [
+        "machine learning is fun",
+        "deep learning uses neural networks",
+        "vector databases store embeddings",
+    ];
+    let mut docs = Vec::new();
+    for (i, text) in texts.iter().enumerate() {
+        let mut doc = Doc::new().unwrap();
+        doc.set_pk(&format!("pk_{}", i));
+        doc.add_string("id", &format!("pk_{}", i)).unwrap();
+        doc.add_string("content", text).unwrap();
+        docs.push(doc);
+    }
+    let doc_refs: Vec<&Doc> = docs.iter().collect();
+    let result = collection.insert(&doc_refs).unwrap();
+    assert_eq!(result.success_count, texts.len() as u64);
+    collection.flush().expect("flush before query");
+
+    // Keyword-only query — no query vector. Builds only via `SearchQuery::fts`.
+    let mut fts = Fts::new().unwrap();
+    fts.set_match_string("learning").unwrap();
+    let query = SearchQuery::fts("content", &fts, 10).expect("build vector-less FTS query");
+
+    let results = collection
+        .query(&query)
+        .expect("vector-less FTS query must run");
+
+    // Exactly the two "learning" docs must come back, and not the third. A
+    // regression where the C query path still demands a dense vector would
+    // error out above instead of returning these rows.
+    let mut got: Vec<String> = results
+        .iter()
+        .map(|d| d.get_string("content").unwrap().unwrap())
+        .collect();
+    got.sort();
+    assert_eq!(
+        got,
+        vec![
+            "deep learning uses neural networks".to_string(),
+            "machine learning is fun".to_string(),
+        ],
+        "keyword query must return exactly the two matching rows"
+    );
+}

--- a/zvec/tests/string_filter_test.rs
+++ b/zvec/tests/string_filter_test.rs
@@ -9,7 +9,7 @@
 //! running. Run with: `cargo test --test string_filter_test`
 
 use std::sync::Once;
-use zvec::*;
+use zvec_rust::*;
 
 static INIT: Once = Once::new();
 


### PR DESCRIPTION
## Summary

Adds `SearchQuery::fts`, a constructor for a pure full-text (keyword-only) query that carries no dense vector.

## Motivation

The C API supports a vector-less FTS query: `zvec_vector_query` does not require a query vector once an FTS payload is attached, and `tests/c/c_api_test.c::test_fts_end_to_end` exercises exactly that path (an FTS-indexed field, no vector field, queried with a match string alone).

The Rust bindings could not reach it. Both ways of building a `SearchQuery` require a vector:

- `SearchQuery::new(field_name, vector, topk)` takes the vector as a positional argument.
- `SearchQueryBuilder::build()` returns `"vector is required"` when `vector` is unset (query.rs, `build()`).

`fts_query_string` / `fts_match_string` on the builder only attach an FTS clause on top of that mandatory vector: that is hybrid search, not keyword-only. There was no way to run a keyword-only query from Rust.

## Change

```rust
/// Creates a pure full-text (keyword-only) search query with no dense vector.
pub fn fts(field_name: &str, fts: &Fts, topk: i32) -> Result<Self>
```

It creates the query handle, sets the field name and topk, and attaches the FTS payload via the existing `set_fts`: the same steps as the C end-to-end test, without the query vector. It wraps the handle in `SearchQuery` before any fallible call, so `Drop` frees it on an early return.

## Test

`zvec/tests/fts_no_vector_test.rs` mirrors the C `test_fts_end_to_end`: a schema with an FTS-indexed string field and no vector field, three inserted docs, and a match-string query built via `SearchQuery::fts`. It asserts the keyword hits come back. A unit test in `query.rs` also covers construction. Both pass against the v0.5.0 prebuilt library.

## Incidental fix

`zvec/tests/string_filter_test.rs` still imported `use zvec::*`, which stopped compiling after the crate was renamed from `zvec` to `zvec-rust`. That breaks the whole test target, so `cargo test` and `cargo clippy --all-targets` fail to build on `main`. Changed it to `use zvec_rust::*`. Happy to split this into its own PR if you'd prefer.
